### PR TITLE
Jenkinsfile: Fixing maven build stages

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -17,28 +17,9 @@ pipeline {
         build 'semantic-reasoner/master'
       }
     }
-    stage ('Build tosca-verification') {
+    stage ('Build verification components') {
       steps {
         sh  """ #!/bin/bash
-                cd tosca
-                mvn clean install
-            """
-        archiveArtifacts artifacts: '**/*.war, **/*.jar', onlyIfSuccessful: true
-      }
-    }
-	stage ('Build ansible-verification') {
-      steps {
-        sh  """ #!/bin/bash
-                cd ansible
-                mvn clean install
-            """
-        archiveArtifacts artifacts: '**/*.war, **/*.jar', onlyIfSuccessful: true
-      }
-    }
-	stage ('Build verification-api') {
-      steps {
-        sh  """ #!/bin/bash
-                cd api
                 mvn clean install
             """
         archiveArtifacts artifacts: '**/*.war, **/*.jar', onlyIfSuccessful: true


### PR DESCRIPTION
When building a Maven project using a `parent` pom, you need to run the `mvn clean install` on the parent pom and not on the children.
See the failure @ https://jenkins.sodalite.eu/job/verification/job/master/2/console